### PR TITLE
Remove buildDiscarder from Jenkins File

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ podTemplate(
                   mountPath: '/cognite-cicd-ssh',
                   readOnly: true)
   ]) {
-    properties([buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '20'))])
+    properties([])
     node(label) {
     def gitCommit
     stage('Checkout code') {


### PR DESCRIPTION
Hello,

This PR has been opened to let you know we need your help.

As part of SOC-2 compliance, we need to store information that confirms that tests have been built on all artifacts that make it to deploy.

Infra has as a consequence done this by bumping the number of builds to keep around in CD to 365 days.

But, we still see builds going missing, and this is probably because people have the buildDiscarder plugin configured in their Jenkinsfile.

The buildDiscarder plugin can have a global default (so we could set that to the same high limit), but there is no way to enforce that it can’t be overridden in the local Jenkinsfile.

More info: https://cognitedata.atlassian.net/browse/INFRA-2891

While we work on a more permanent solution, we request you to clear the line in your Jenkinsfiles related to buildDiscarder e.g. https://github.com/cognitedata/applications/blob/master/Jenkinsfile#L106

Thanks for the understanding,
The Infra team.

P.S the PR has been generated via a script since there are quite a few repos that require this change.